### PR TITLE
fix: getMessagePrefix has the correct formating

### DIFF
--- a/sources/ServerMessages.cpp
+++ b/sources/ServerMessages.cpp
@@ -143,7 +143,7 @@ void	ServerMessages::RPL_WHOREPLY( int socketFd, User* user, const std::string& 
 
 // JOIN_MESSAGE
 void	ServerMessages::JOIN_MESSAGE( const int socketFd, User* user, const std::string& channelName ) {
-	std::string	message( ":" + user->getNickname() + "!" + user->getUsername() + "@" + user->getIp() + " "\
+	std::string	message( ":" + user->getNickname() + "!" + user->getUsername() + "@" + user->getIp()\
 		+ " JOIN " + channelName + "\r\n" );
 	
 	send( socketFd, message.c_str(), message.size(), 0 );

--- a/sources/User.cpp
+++ b/sources/User.cpp
@@ -72,7 +72,7 @@ void	User::setNicknameStatusTrue() { _nicknameStatus = true; }
 void	User::setIsAuthenticatedTrue() { _isAuthenticated = true; }
 
 std::string	User::getMessagePrefix() const {
-	std::string	messagePrefix( _nickname + "!" + _username + "@" + _ip +" " );
+	std::string	messagePrefix( ":" + _nickname + "!" + _username + "@" + _ip +" " );
 	return ( messagePrefix );
 }
 


### PR DESCRIPTION
eliminated extra space in JOIN_MESSAGE