### PR TITLE
fix: improve memory usage and prevent memory duplication on class Channel

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -17,6 +17,7 @@
 #include <signal.h>
 #include <algorithm>
 #include <map>
+#include <set>
 
 #include "User.hpp"
 
@@ -41,10 +42,9 @@ class Channel {
 		const std::string&						getTopic() const;
 		std::string								getModes() const;
   		User*									getUser( const std::string& nickname );
-		User*									getOperator( const std::string& nickname );
 		std::map<std::string, User*>&			getUsers();
-		std::map<std::string, User*>&			getOperators();
-		std::map<std::string, User*>&			getInvites();
+		std::set<std::string>&					getOperators();
+		std::set<std::string>&					getInvites();
 		int										getUserLimit() const;
 		int										getUserCount() const;
 		bool									getInviteOnly() const;
@@ -60,13 +60,13 @@ class Channel {
 		void									setInviteOnly( bool inviteOnly );
 		void									setTopicRestriction( bool topicRestriction );
 		void									addUser( User* newUser );
-		void									addOperator( User* newOperator );
-		void									addInvite( User* newInvite );
+		void									addOperator( const std::string& newOperator );
+		void									addInvite( const std::string& newInvite );
 
 		//Removers
-		void									ejectUser( User* user);
-		void									ejectOperator(User* user);
-		void									removeInvite(User* invite);
+		void									ejectUser( const std::string& user);
+		void									ejectOperator( const std::string& user);
+		void									removeInvite( const std::string& invite);
 
 		//Functions
 		void									sendMessage( std::string serverMessage, std::string senderNick );
@@ -81,6 +81,6 @@ class Channel {
 		bool									_topicRestriction;
 
 		std::map<std::string, User*>			_users;
-		std::map<std::string, User*>			_operators;
-		std::map<std::string, User*>			_inviteList;
+		std::set<std::string>					_operators;
+		std::set<std::string>					_inviteList;
 };

--- a/sources/Channel.cpp
+++ b/sources/Channel.cpp
@@ -40,20 +40,13 @@ const std::string&	Channel::getTopic() const { return ( _topic ); }
 
 std::map<std::string, User*>&	Channel::getUsers() { return ( _users ); }
 
-std::map<std::string, User*>&	Channel::getOperators() { return ( _operators ); }
+std::set<std::string>&	Channel::getOperators() { return ( _operators ); }
 
-std::map<std::string, User*>&	Channel::getInvites() { return ( _inviteList ); }
+std::set<std::string>&	Channel::getInvites() { return ( _inviteList ); }
 
 User*	Channel::getUser( const std::string& nickname ) {
 	std::map<std::string, User*>::iterator	it = _users.find( nickname );
 	if ( it != _users.end() )
-		return ( it->second );
-	return ( NULL );
-}
-
-User*	Channel::getOperator( const std::string& nickname ) {
-	std::map<std::string, User*>::iterator	it = _operators.find( nickname );
-	if ( it != _operators.end() )
 		return ( it->second );
 	return ( NULL );
 }
@@ -119,19 +112,19 @@ void	Channel::addUser( User* newUser ) {
 	_users.insert( std::pair<std::string, User*>( ( newUser->getNickname() ), newUser ) ); 
 }
 
-void	Channel::addOperator( User* newOperator ) { 
-	_operators.insert( std::pair<std::string, User*>( ( newOperator->getNickname() ), newOperator ) );
+void	Channel::addOperator( const std::string& newOperator ) { 
+	_operators.insert( newOperator );
 }
 
-void	Channel::addInvite( User* newInvite ) { 
-	_inviteList.insert( std::pair<std::string, User*>( ( newInvite->getNickname() ), newInvite ) ); 
+void	Channel::addInvite( const std::string& newInvite ) { 
+	_inviteList.insert( newInvite ); 
 }
 
-void	Channel::ejectUser( User* user ) { _users.erase( user->getNickname() ); }
+void	Channel::ejectUser( const std::string& user ) { _users.erase( user ); }
 
-void	Channel::ejectOperator( User* user ) { _operators.erase( user->getNickname() ); }
+void	Channel::ejectOperator( const std::string& user ) { _operators.erase( user ); }
 
-void	Channel::removeInvite( User* user ) { _inviteList.erase( user->getNickname() ); }
+void	Channel::removeInvite( const std::string& invite ) { _inviteList.erase( invite ); }
 
 void	Channel::sendMessage( std::string serverMessage , std::string senderNick ) {
 	for ( std::map<std::string, User*>::iterator it = _users.begin(); it != _users.end(); it++ ) {
@@ -139,11 +132,4 @@ void	Channel::sendMessage( std::string serverMessage , std::string senderNick ) 
 			continue;
 		send( it->second->getSocketFd(), serverMessage.c_str(), serverMessage.size(), 0 );
 	}
-}
-
-bool	Channel::isOperator( User* user ) {
-	std::map<std::string, User*>::iterator	it = _operators.find( user->getNickname() );
-	if ( it != _operators.end() )
-		return ( true );
-	return ( false );
 }

--- a/sources/Commands.cpp
+++ b/sources/Commands.cpp
@@ -51,7 +51,7 @@ void	Server::createNewChannel( std::string& channelName, User* user ) {
 	Channel channel( channelName );
 	
 	channel.addUser( user );
-	channel.addOperator( user );
+	channel.addOperator( user->getNickname() );
 	addChannel( channel );
 	user->addChannel( channelName, &_channels[channelName]);
 
@@ -83,7 +83,7 @@ void	Server::addUserToChannel( std::string& channelName, User* user, std::vector
 	
 	if ( channelPassword.empty() == false )
 		channelsKeys.erase( channelsKeys.begin() );
-	channel.removeInvite( user );
+	channel.removeInvite( user->getNickname() );
 	channel.addUser( user );
 	user->addChannel( channelName, &channel );
 
@@ -172,7 +172,7 @@ void	Server::changeNickInChannel( User* newUser, std::vector< Channel* >& regula
 	chanIt = operatorChannels.begin();
 	for (; chanIt != operatorChannels.end(); ++chanIt ) {
 		channel = getChannel( (*chanIt)->getName() );
-		channel->addOperator( newUser );
+		channel->addOperator( newUser->getNickname() );
 		channel->addUser( newUser );
 		newUser->addChannel( channel->getName(), channel );
 	}
@@ -294,7 +294,7 @@ void	Server::kickCommand( int userSocket, const std::string& command ) {
 		return;
 	}
 
-	channel->ejectUser( target );
+	channel->ejectUser( target->getNickname() );
 	std::string comment = ":Because you stink ";
 	
 	if ( parameters.size() > 3 && parameters.at( 3 ).at( 0 ) == ':' ) {
@@ -336,7 +336,7 @@ void	Server::partCommand( int userSocket, std::string& command ) {
 		return;
 	}
 
-	channel->ejectUser( user );
+	channel->ejectUser( user->getNickname() );
 	ServerMessages::PART_MESSAGE( userSocket, user,  channel );
 }
 
@@ -358,7 +358,7 @@ void	Server::quitCommand( int userSocket, std::string& command ) {
 
 	for (; chanIt != channelsMap.end(); ++chanIt ) { // Removes user from channels he is part of
 		channel = getChannel( chanIt->first );
-		channel->ejectUser( user );
+		channel->ejectUser( user->getNickname() );
 	}
 	_commandInput.erase( userSocket );
 
@@ -467,7 +467,7 @@ void	Server::modeChannel( User* sender, std::vector< std::string > params, Chann
 		return ;
 	}
 
-	if ( ch->isOperator( sender ) == false ) {
+	if ( ch->isOperator( sender->getNickname() ) == false ) {
 		ServerMessages::ERR_CHANOPRIVSNEEDED( sender->getSocketFd(), sender->getNickname(), ch->getName() );
 		return ;
 	}
@@ -554,9 +554,9 @@ void	Server::modeOperator( Channel *channel, std::string flag, User* sender, std
 		return ;
 	}
 	if ( flag.find( '+' ) != std::string::npos )
-		channel->addOperator( rec );
+		channel->addOperator( rec->getNickname() );
 	else
-		channel->ejectOperator( rec );
+		channel->ejectOperator( rec->getNickname() );
 	modeMessage( sender, channel->getName(), flag, receiver );
 }
 
@@ -616,7 +616,7 @@ void	Server::inviteCommand( int userSocket, std::string& command ) {
 		return ;
 	}
 
-	channel->addInvite( target );
+	channel->addInvite( target->getNickname() );
 	ServerMessages::RPL_INVITING( userSocket, user->getNickname(), target->getNickname(), channel->getName() ); // RPL_INVITING 341
 	ServerMessages::INVITE_MESSAGE( target->getSocketFd(), user, target->getNickname(), channel->getName() ); // INVITE_MESSAGE
 }

--- a/sources/Server.cpp
+++ b/sources/Server.cpp
@@ -75,7 +75,7 @@ void	Server::removeUser( User* user ) {
 
 	for (; chanIt != channelsMap.end(); ++chanIt ) { // Removes user from channels he is part of
 		channel = getChannel( chanIt->first );
-		channel->ejectUser( user );
+		channel->ejectUser( user->getNickname() );
 	}
 	_usersBySocket.erase( user->getSocketFd() );
 	_users.erase( user->getNickname() );

--- a/sources/ServerMessages.cpp
+++ b/sources/ServerMessages.cpp
@@ -175,11 +175,12 @@ void	ServerMessages::RPL_WHOREPLY( int socketFd, User* user, const std::string& 
 
 // RPL_NAMREPLY 353
 void	ServerMessages::RPL_NAMREPLY( int socketFd, User* user, Channel* channel ) {
-	std::map< std::string, User* >& _users = channel->getUsers();
-
+	std::map< std::string, User* >& users = channel->getUsers();
 	std::string message( ":Tijolinhos 353 " + user->getNickname() + " = " + channel->getName() + " :" );
-	for ( std::map<std::string, User*>::iterator it = _users.begin(); it != _users.end(); it++ ) {
-		if ( channel->isOperator( it->second ) )
+	
+	std::map<std::string, User*>::iterator it = users.begin();
+	for ( ; it != users.end(); it++ ) {
+		if ( channel->isOperator( it->first ) )
 			message += '@';
 		message += it->first + " ";
 	}

--- a/sources/User.cpp
+++ b/sources/User.cpp
@@ -48,7 +48,7 @@ std::vector< Channel* >	User::getRegularChannels() {
 	Channel*										channel;
 	for (; chanIt != _channels.end(); ++chanIt ) {
 		channel = chanIt->second;
-		if ( channel->isOperator( this ) == false )
+		if ( channel->isOperator( _nickname ) == false )
 			regularChannels.push_back( channel );
 	}
 	return ( regularChannels );
@@ -61,7 +61,7 @@ std::vector< Channel* >	User::getOperatorChannels() {
 	Channel*										channel;
 	for (; chanIt != _channels.end(); ++chanIt ) {
 		channel = chanIt->second;
-		if ( channel->isOperator( this ) )
+		if ( channel->isOperator( _nickname ) )
 			operatorChannels.push_back( channel );
 	}
 	return ( operatorChannels );


### PR DESCRIPTION
Changed _operatos and _inviteList on Channel to a Set.

 Changed functions because of unecessary use of pointers when only a string is needed.